### PR TITLE
fix: change bulk write to use pointers for batcher interface to work

### DIFF
--- a/postgres-driver/relay.go
+++ b/postgres-driver/relay.go
@@ -145,7 +145,7 @@ func (d *PostgresDriver) WriteRelay(ctx context.Context, relay types.Relay) erro
 	})
 }
 
-func (d *PostgresDriver) WriteRelays(ctx context.Context, relays []types.Relay) error {
+func (d *PostgresDriver) WriteRelays(ctx context.Context, relays []*types.Relay) error {
 	now := time.Now()
 
 	var (

--- a/postgres-driver/relay_test.go
+++ b/postgres-driver/relay_test.go
@@ -59,9 +59,9 @@ func (ts *PGDriverTestSuite) TestPostgresDriver_WriteRelay() {
 }
 
 func (ts *PGDriverTestSuite) TestPostgresDriver_WriteRelays() {
-	var relays []types.Relay
+	var relays []*types.Relay
 	for i := 0; i < 1000; i++ {
-		relays = append(relays, types.Relay{
+		relays = append(relays, &types.Relay{
 			PoktChainID:              "21",
 			EndpointID:               "21",
 			SessionKey:               ts.firstRelay.SessionKey,
@@ -93,7 +93,7 @@ func (ts *PGDriverTestSuite) TestPostgresDriver_WriteRelays() {
 
 	tests := []struct {
 		name   string
-		relays []types.Relay
+		relays []*types.Relay
 		err    error
 	}{
 		{

--- a/postgres-driver/service_record.go
+++ b/postgres-driver/service_record.go
@@ -88,7 +88,7 @@ func (d *PostgresDriver) WriteServiceRecord(ctx context.Context, serviceRecord t
 	})
 }
 
-func (d *PostgresDriver) WriteServiceRecords(ctx context.Context, serviceRecords []types.ServiceRecord) error {
+func (d *PostgresDriver) WriteServiceRecords(ctx context.Context, serviceRecords []*types.ServiceRecord) error {
 	now := time.Now()
 
 	var (

--- a/postgres-driver/service_record_test.go
+++ b/postgres-driver/service_record_test.go
@@ -40,9 +40,9 @@ func (ts *PGDriverTestSuite) TestPostgresDriver_WriteServiceRecord() {
 }
 
 func (ts *PGDriverTestSuite) TestPostgresDriver_WriteServiceRecords() {
-	var serviceRecords []types.ServiceRecord
+	var serviceRecords []*types.ServiceRecord
 	for i := 0; i < 1000; i++ {
-		serviceRecords = append(serviceRecords, types.ServiceRecord{
+		serviceRecords = append(serviceRecords, &types.ServiceRecord{
 			NodePublicKey:          "21",
 			PoktChainID:            "21",
 			SessionKey:             ts.firstServiceRecord.SessionKey,
@@ -63,7 +63,7 @@ func (ts *PGDriverTestSuite) TestPostgresDriver_WriteServiceRecords() {
 
 	tests := []struct {
 		name           string
-		serviceRecords []types.ServiceRecord
+		serviceRecords []*types.ServiceRecord
 		err            error
 	}{
 		{


### PR DESCRIPTION
Change bulk writes to use pointers for batcher interface to work